### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Radius Pi-Sphere
+Quick Calculations for finding the radius of a sphere with pi 
+
+
+[![Run on Repl.it](https://repl.it/badge/github/AmieDD/Radius-pi-sphere)](https://repl.it/github/AmieDD/Radius-pi-sphere)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@AmieDD/Radius-of-a-sphere-using-pi-314).